### PR TITLE
jsonnet: Fix openshift-dashboard definition

### DIFF
--- a/jsonnet/Openshiftmetrics.jsonnet
+++ b/jsonnet/Openshiftmetrics.jsonnet
@@ -1,4 +1,9 @@
 {
+  _config+:: {
+    grafanaDashboardIDs+:: {
+      'openshift-dashboard.json': 'abcd',
+    },
+  },
   grafanaDashboards+:: {
     "openshift-dashboard.json":
       local grafana = import 'grafonnet/grafana.libsonnet';

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -1,5 +1,5 @@
-local kp = (import 'Openshiftmetrics.jsonnet') +
-           (import 'kube-prometheus/kube-prometheus.libsonnet') +
+local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
+           (import 'Openshiftmetrics.jsonnet') +
            (import 'kube-prometheus/kube-prometheus-static-etcd.libsonnet') +
            {
              _config+:: {


### PR DESCRIPTION
Necessary changes:

**`jsonnet/main.jsonnet`**

`kube-prometheus` needs to be imported before `Openshiftmetrics`, as
`kube-prometheus` imports `grafana/grafana`, which sets the
`grafanaDashboards` to `{}`.

**`jsonnet/Openshiftmetrics.jsonnet`**

In order for the following to work

```jsonnet
uid=($._config.grafanaDashboardIDs['openshift-dashboard.json']),`
```

`_config.grafanaDashboardIDs` needs to be defined.

@rockash let me know if this sounds reasonable or if you have any further questions.